### PR TITLE
Add Bitcoin DA client documentation

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -14,6 +14,7 @@
   - [Architecture](guides/architecture.md)
   - [Build Docker](guides/build-docker.md)
   - [Repositories](guides/repositories.md)
+  - [Bitcoin DA client](guides/bitcoin-da-client.md)
 
 - [Advanced](guides/advanced/README.md)
   - [Local initialization](guides/advanced/01_initialization.md)

--- a/docs/src/guides/advanced/07_fee_model.md
+++ b/docs/src/guides/advanced/07_fee_model.md
@@ -110,7 +110,7 @@ If you're running a system with validium without any DA, you can just set the `l
 `max_pubdata_per_batch` to some large value, and set `pubdata_overhead_part` to 0, and `compute_overhead_part` to 1.
 
 If you're running alternative DA, you should adjust the `l1_pubdata_price` to roughly cover the cost of writing one byte
-to the DA, and set `max_pubdata_per_batch` to the DA limits.
+to the DA, and set `max_pubdata_per_batch` to the DA limits. See [Bitcoin DA client](../bitcoin-da-client.md) for an example of configuring an alternative layer.
 
 Note: currently system still requires operator to keep the data in memory and compress it, which means that setting huge
 values of `max_pubdata_per_batch` might not work. This will be fixed in the future.

--- a/docs/src/guides/bitcoin-da-client.md
+++ b/docs/src/guides/bitcoin-da-client.md
@@ -1,0 +1,33 @@
+# Bitcoin Data Availability client
+
+This section explains how to enable the Bitcoin DA client for zkSync nodes. The
+implementation leverages the [Syscoin PoDA service](https://github.com/syscoin)
+to store data off chain. PoDA is not a standard Bitcoin node: it runs on a
+Syscoin node that is secured by Bitcoin miners through merged mining.
+
+## Enabling the client
+
+Set `DA_CLIENT=Bitcoin` in your environment or configuration file. For the External Node the variables should be prefixed with `EN_` (e.g. `EN_DA_CLIENT`).
+
+### Required variables
+
+- `BITCOIN_API_NODE_URL` &ndash; URL of the Syscoin node that exposes Bitcoin
+  chain data.
+- `BITCOIN_PODA_URL` &ndash; endpoint of the PoDA service used to publish data on
+  the merged-mined Syscoin chain.
+- `DA_SECRETS_RPC_USER` &ndash; RPC user name for authenticating with PoDA.
+- `DA_SECRETS_RPC_PASSWORD` &ndash; RPC password for PoDA.
+
+Put secret values into your secrets configuration or export them as environment variables. Example:
+
+```bash
+export DA_CLIENT=Bitcoin
+export BITCOIN_API_NODE_URL="https://bitcoin-node.example.com"
+export BITCOIN_PODA_URL="https://poda.example.com"
+export DA_SECRETS_RPC_USER="user"
+export DA_SECRETS_RPC_PASSWORD="password"
+```
+
+For instructions on running the PoDA service and Syscoin node see the
+[Syscoin GitHub repository](https://github.com/syscoin).
+

--- a/docs/src/guides/external-node/11_setup_for_other_chains.md
+++ b/docs/src/guides/external-node/11_setup_for_other_chains.md
@@ -47,4 +47,4 @@ to the components list, e.g. for a standard list of components and DA fetcher it
 
 To configure the DA fetcher, you need to add the `da_client` config if the file-based config is used or configure in via
 the environment variables, they need to have an `EN_` prefix. If the DA client in use needs a secret to be configured -
-you need to set it in your secrets config or a corresponding environment variable.
+you need to set it in your secrets config or a corresponding environment variable. For details on configuring the Bitcoin layer see [Bitcoin DA client](../bitcoin-da-client.md).

--- a/docs/src/specs/contracts/chain_management/chain_type_manager.md
+++ b/docs/src/specs/contracts/chain_management/chain_type_manager.md
@@ -23,7 +23,7 @@ In the long term vision chains deployment will be permissionless, however CTM wi
 
 ## Configurability in the current release
 
-For now, only one CTM will be supported — the one that deploys instances of ZKsync Era, possibly using other DA layers. To read more about different DA layers, check out [this document][TODO].
+For now, only one CTM will be supported — the one that deploys instances of ZKsync Era, possibly using other DA layers. To read more about different DA layers, check out the [Bitcoin DA client guide](../../../guides/bitcoin-da-client.md).
 
 The exact process of deploying & registering a chain can be [read here](./chain_genesis.md). Overall, each chain in the current release will have the following parameters:
 


### PR DESCRIPTION
## Summary
- document how to enable the Bitcoin DA client
- link to this guide from setup docs mentioning alternative DA layers
- clarify PoDA runs on Syscoin merged-mined with Bitcoin

## Testing
- `git status --short`
