### PR TITLE
Add gateway launch guide and Bitcoin DA config snippet

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -15,6 +15,7 @@
   - [Build Docker](guides/build-docker.md)
   - [Repositories](guides/repositories.md)
   - [Bitcoin DA client](guides/bitcoin-da-client.md)
+  - [Gateway launch](guides/gateway-launch.md)
 
 - [Advanced](guides/advanced/README.md)
   - [Local initialization](guides/advanced/01_initialization.md)

--- a/docs/src/guides/bitcoin-da-client.md
+++ b/docs/src/guides/bitcoin-da-client.md
@@ -28,3 +28,24 @@ export DA_SECRETS_RPC_PASSWORD="password"
 
 For instructions on running the PoDA service and Syscoin node see the
 [Syscoin GitHub repository](https://github.com/syscoin).
+
+### `smart_config` example
+
+To configure the node with the new layered configuration format, add a fragment similar to:
+
+```yaml
+da_client:
+  client: Bitcoin
+  api_node_url: https://bitcoin-node.example.com
+  poda_url: https://poda.example.com
+```
+
+Secrets can be provided via `secrets.yaml` or environment variables:
+
+```yaml
+da_client:
+  rpc_user: user
+  rpc_password: password
+```
+
+When using Bitcoin DA for Validium, set `state_keeper.max_pubdata_per_batch` to about `2_000_000` bytes. See [Configuration Format Changes](../announcements/config_format_changes.md) for details.

--- a/docs/src/guides/gateway-launch.md
+++ b/docs/src/guides/gateway-launch.md
@@ -1,0 +1,45 @@
+# Launching a chain on ZK Gateway with Bitcoin DA
+
+This tutorial shows how to deploy Gateway contracts, create the first chain using Bitcoin as the data availability layer, and run the node using the new `smart_config` format.
+
+1. **Create the ecosystem and initialize contracts**
+
+   ```bash
+   zkstack ecosystem create
+   zkstack ecosystem init
+   ```
+
+2. **Create the chain using Bitcoin Validium**
+
+   ```bash
+   zkstack chain create \
+       --l1-batch-commit-data-generator-mode validium \
+       --validium-type bitcoin
+   ```
+
+3. **Deploy the chain and register it on Gateway**
+
+   ```bash
+   zkstack chain init --gateway-config-path ./etc/env/ecosystems/gateway/stage_gateway.yaml
+   ```
+
+   The command deploys the contracts, registers the chain in the BridgeHub, and uses the Gateway configuration file.
+
+4. **Adjust the chain configuration**
+
+   Edit `chains/<chain_name>/configs/general.yaml` and set
+
+   ```yaml
+   state_keeper:
+     max_pubdata_per_batch: 2_000_000
+   ```
+
+   Add the [Bitcoin DA smart_config](./bitcoin-da-client.md#smart_config-example) snippet for the DA client.
+
+5. **Run the node**
+
+   ```bash
+   zkstack server
+   ```
+
+This launches the first zkSYS chain on Gateway with Bitcoin providing off-chain data availability.

--- a/zkstack_cli/README.md
+++ b/zkstack_cli/README.md
@@ -145,6 +145,10 @@ The first ZK chain is generated upon ecosystem creation. You can also create add
 ```bash
 zkstack chain create
 ```
+Use `--l1-batch-commit-data-generator-mode validium` together with `--validium-type` to select an alternative DA layer. Example for Bitcoin:
+```bash
+zkstack chain create --l1-batch-commit-data-generator-mode validium --validium-type bitcoin
+```
 
 #### Init
 


### PR DESCRIPTION
## Summary
- add smart_config YAML example and 2 MB pubdata recommendation for Bitcoin DA
- document gateway chain launch workflow
- mention `--validium-type` flag in zkstack CLI README
- include new guide in the book summary

## Testing
- `cargo fmt --all` *(fails: could not download file)*